### PR TITLE
feat: Support urllib3 2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from codecs import open
 
 requires = [
     'requests <3.0, >=2.18.0',
-    'urllib3 <2.0, >=1.22',
+    'urllib3 <3.0, >=1.22',
     'psutil'
 ]
 


### PR DESCRIPTION
## What

Raise the `urllib3` requirement cap from `<2.0` to `<3.0` in `setup.py`.
I reviewed the changes in the migration guide and looked through our usage, and there do not seem to be changes that impact our usage. https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html

urllib 2.7.0 is the version we need to upgrade semgrep-app to, I ran the test suite locally with that version. 

## Why

Need to remediate CVEs in semgrep-app by upgrading urllib, but advocate caps urllib<2.0. 
